### PR TITLE
Enhancements to API

### DIFF
--- a/oc/classes/controller/api/ads.php
+++ b/oc/classes/controller/api/ads.php
@@ -283,4 +283,34 @@ class Controller_Api_Ads extends Api_User {
         }
     }
 
+    public function action_set_primary_image()
+    {
+        try
+        {
+
+            if (is_numeric($id_ad = $this->request->param('id')) AND is_numeric($num_image = $this->_post_params['num_image']))
+            {
+                $ad = new Model_Ad();
+                $ad->where('id_ad','=',$id_ad)->where('id_user','=',$this->user->id_user)->find();
+
+                if ($ad->loaded())
+                {
+                    if ($ret = $ad->set_primary_image($num_image))
+                        $this->rest_output($ret);
+                    else
+                        $this->_error($ret);         
+                }
+                else
+                    $this->_error(__('Advertisement not found'),404);
+            }
+            else
+                $this->_error(__('Advertisement not found'),404);
+
+        }
+        catch (Kohana_HTTP_Exception $khe)
+        {
+            $this->_error($khe);
+        }
+    }
+
 } // END

--- a/oc/classes/controller/api/categories.php
+++ b/oc/classes/controller/api/categories.php
@@ -82,6 +82,33 @@ class Controller_Api_Categories extends Api_Controller {
         }
     }
 
+    /**
+     * Handle GET requests.
+     */
+    public function action_count()
+    {
+        try
+        {
+            if (isset($this->_params['id_location']) && is_numeric($this->_params['id_location']))
+            {
+                $location = new Model_Location($this->_params['id_location']);
+                if ($location->loaded())
+                {
+                    $output = Model_Category::get_category_count(TRUE, $location);
+                }
+            }
+            else
+            {
+                $output = Model_Category::get_category_count(FALSE);
+            }
+            $this->rest_output(array('categories' => $output),200,count($output));
+        }
+        catch (Kohana_HTTP_Exception $khe)
+        {
+            $this->_error($khe);
+        }
+    }
+
     public function action_get()
     {
         try

--- a/oc/classes/controller/api/profile.php
+++ b/oc/classes/controller/api/profile.php
@@ -65,13 +65,36 @@ class Controller_Api_Profile extends Api_User {
     }
 
 
-    //deletes a picture
+    /**
+     * Delete picture action.
+     * 
+     * Optionally deletes a specific image by number using param 'num_image'.
+     * If 'num_image' is not submitted, the primary image will be deleted instead.
+     */
     public function action_picture_delete()
     {
-        if ($this->user->delete_image()==TRUE )
-            $this->rest_output(TRUE);
-        else
-            $this->_error(FALSE);
+        try
+        {
+            $num_image = null;
+
+            if (isset($this->_post_params['num_image'])) {
+                $num_image = $this->_post_params['num_image'];
+            }
+
+            if (!is_numeric($num_image)) {
+                $num_image = 1;
+            }
+
+            if ($this->user->delete_image($num_image)==TRUE ) {
+                $this->rest_output(TRUE);
+            } else {
+                $this->_error(FALSE);
+            }
+        }
+        catch (Kohana_HTTP_Exception $khe)
+        {
+            $this->_error($khe);
+        }
     }
 
 


### PR DESCRIPTION
I started using yclas for one of my projects which is still WIP. As this project is strongly based on the API of yclas, I work on some improvements which I would like starting to share. 
I kindly ask to review the following changes:
- added a new "count" action to API categories controller which aligns the API to the possibilities of the frontend (mainly to display the number of ads in a category without additional requests)
- added a new "set_primary_image_action" action to API ads controller which aligns the API to the possibilities of the frontend
- fixed an issue in the 'picture_delete' action in API profile controller, this change was necessary because the action has used the function 'delete_image()' without providing a parameter.
- additionally added optional parameter 'num_image' to the 'picture_delete' action in API profile controller which no allows to delete a specific user profile image

May this changes can be merged in upcoming release, so that it will bring some improvements for other users. This changes should not be break the backward compatibility at any point.

I appreciate any feedback, and if wanted, I will keep submitting further pull request.