### PR TITLE
PHP 8 Compatibility

### DIFF
--- a/oc/classes/model/field.php
+++ b/oc/classes/model/field.php
@@ -537,7 +537,7 @@ class Model_Field {
      * list with fields we dont show to users
      * @return array
      */
-    public function fields_to_hide()
+    public static function fields_to_hide()
     {
         return array (
             'cf_buyer_instructions',

--- a/oc/kohana/system/classes/Kohana/Arr.php
+++ b/oc/kohana/system/classes/Kohana/Arr.php
@@ -101,7 +101,13 @@ class Kohana_Arr {
 		}
 		else
 		{
-			if (array_key_exists($path, $array))
+			if (is_array($array) AND array_key_exists($path, $array))
+			{
+				// No need to do extra processing
+				return $array[$path];
+            }
+
+            if (is_object($array) AND property_exists($array, $path))
 			{
 				// No need to do extra processing
 				return $array[$path];


### PR DESCRIPTION
I have been testing (🏄) PHP 8 and will keep updated this PR with incompatibilities and possible fixes.

- Fix array_key_exists() on objects.
  > Using array_key_exists() on objects is deprecated since PHP 7.4