### PR TITLE
Add PHP 8 compatibility

### DIFF
--- a/oc/classes/arr.php
+++ b/oc/classes/arr.php
@@ -61,4 +61,135 @@ class Arr extends Kohana_Arr {
 
         return $files;
     }
+
+
+	/**
+	 * Gets a value from an array using a dot separated path.
+	 *
+	 *     // Get the value of $array['foo']['bar']
+	 *     $value = Arr::path($array, 'foo.bar');
+	 *
+	 * Using a wildcard "*" will search intermediate arrays and return an array.
+	 *
+	 *     // Get the values of "color" in theme
+	 *     $colors = Arr::path($array, 'theme.*.color');
+	 *
+	 *     // Using an array of keys
+	 *     $colors = Arr::path($array, array('theme', '*', 'color'));
+	 *
+	 * @param   array   $array      array to search
+	 * @param   mixed   $path       key path string (delimiter separated) or array of keys
+	 * @param   mixed   $default    default value if the path is not set
+	 * @param   string  $delimiter  key path delimiter
+	 * @return  mixed
+	 */
+	public static function path($array, $path, $default = NULL, $delimiter = NULL)
+	{
+		if ( ! Arr::is_array($array))
+		{
+			// This is not an array!
+			return $default;
+		}
+
+		if (is_array($path))
+		{
+			// The path has already been separated into keys
+			$keys = $path;
+		}
+		else
+		{
+			if (is_array($array) AND array_key_exists($path, $array))
+			{
+				// No need to do extra processing
+				return $array[$path];
+			}
+
+			if (is_object($array) AND property_exists($array, $path))
+			{
+				// No need to do extra processing
+				return $array[$path];
+			}
+
+			if ($delimiter === NULL)
+			{
+				// Use the default delimiter
+				$delimiter = Arr::$delimiter;
+			}
+
+			// Remove starting delimiters and spaces
+			$path = ltrim($path, "{$delimiter} ");
+
+			// Remove ending delimiters, spaces, and wildcards
+			$path = rtrim($path, "{$delimiter} *");
+
+			// Split the keys by delimiter
+			$keys = explode($delimiter, $path);
+		}
+
+		do
+		{
+			$key = array_shift($keys);
+
+			if (ctype_digit($key))
+			{
+				// Make the key an integer
+				$key = (int) $key;
+			}
+
+			if (isset($array[$key]))
+			{
+				if ($keys)
+				{
+					if (Arr::is_array($array[$key]))
+					{
+						// Dig down into the next part of the path
+						$array = $array[$key];
+					}
+					else
+					{
+						// Unable to dig deeper
+						break;
+					}
+				}
+				else
+				{
+					// Found the path requested
+					return $array[$key];
+				}
+			}
+			elseif ($key === '*')
+			{
+				// Handle wildcards
+
+				$values = [];
+				foreach ($array as $arr)
+				{
+					if ($value = Arr::path($arr, implode('.', $keys)))
+					{
+						$values[] = $value;
+					}
+				}
+
+				if ($values)
+				{
+					// Found the values requested
+					return $values;
+				}
+				else
+				{
+					// Unable to dig deeper
+					break;
+				}
+			}
+			else
+			{
+				// Unable to dig deeper
+				break;
+			}
+		}
+		while ($keys);
+
+		// Unable to find the value requested
+		return $default;
+	}
 }

--- a/oc/classes/model/field.php
+++ b/oc/classes/model/field.php
@@ -544,7 +544,7 @@ class Model_Field {
      * list with fields we dont show to users
      * @return array
      */
-    public function fields_to_hide()
+    public static function fields_to_hide()
     {
         return array (
             'cf_buyer_instructions',


### PR DESCRIPTION
It fixes the array_key_exists() on objects at line https://github.com/yclas/yclas/blob/master/oc/kohana/system/classes/Kohana/Arr.php#L104, and It's backwards compatible with PHP 7.4.

> Using array_key_exists() on objects is deprecated since PHP 7.4: https://www.php.net/manual/en/migration74.deprecated.php